### PR TITLE
Use subprocess.run + strip env vars on start

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # ulauncher-vscode-recent
+[![Build Status](https://2903-109-70-50-58.ngrok-free.app/api/badges/SK-FComputer/ulauncher-vscode-recent/status.svg)](https://2903-109-70-50-58.ngrok-free.app/SK-FComputer/ulauncher-vscode-recent)
 
 > 💻 Open recent VS Code folders and files using Ulauncher.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # ulauncher-vscode-recent
-[![Build Status](https://2903-109-70-50-58.ngrok-free.app/api/badges/SK-FComputer/ulauncher-vscode-recent/status.svg)](https://2903-109-70-50-58.ngrok-free.app/SK-FComputer/ulauncher-vscode-recent)
 
 > 💻 Open recent VS Code folders and files using Ulauncher.
 

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import json
 import logging
 import pathlib
 import sqlite3
+import subprocess
 from ulauncher.api.client.Extension import Extension
 from ulauncher.api.client.EventListener import EventListener
 from ulauncher.api.shared.event import (
@@ -130,14 +131,26 @@ class Code:
 			})
 		return recents
 
-	def open_vscode(self, recent):
+	def open_vscode(self, recent, excluded_env_vars):
 		if not self.is_installed():
 			return
-		os.system(f"{self.installed_path} {recent['option']} {recent['uri']}")
+		# Get the current environment variables
+		current_env = os.environ.copy()
+
+		# Remove the environment variables that we don't want to pass to the new process if any
+		if excluded_env_vars:
+			for env_var in excluded_env_vars.split(','):
+				env_to_exclude = env_var.strip()
+				if env_to_exclude in current_env:
+					del current_env[env_to_exclude]
+
+		# Start the new process with the modified environment
+		subprocess.run([self.installed_path, recent['option'], recent['uri']], env=current_env)
 
 
 class CodeExtension(Extension):
 	keyword = None
+	excluded_env_vars = None
 	code = None
 
 	def __init__(self):
@@ -201,18 +214,21 @@ class KeywordQueryEventListener(EventListener):
 class ItemEnterEventListener(EventListener):
 	def on_event(self, event, extension):
 		recent = event.get_data()
-		extension.code.open_vscode(recent)
+		extension.code.open_vscode(recent, extension.excluded_env_vars)
 
 
 class PreferencesEventListener(EventListener):
 	def on_event(self, event, extension):
 		extension.keyword = event.preferences["code_kw"]
+		extension.excluded_env_vars = event.preferences['excluded_env_vars']
 
 
 class PreferencesUpdateEventListener(EventListener):
 	def on_event(self, event, extension):
 		if event.id == "code_kw":
 			extension.keyword = event.new_value
+		if event.id == "excluded_env_vars":
+			extension.excluded_env_vars = event.new_value
 
 
 if __name__ == "__main__":

--- a/manifest.json
+++ b/manifest.json
@@ -1,15 +1,20 @@
 {
-  "required_api_version": "^2.0.0",
-  "name": "VS Code Recent",
-  "description": "Quickly open recently-opened VS Code project directories and files",
-  "developer_name": "plibither8",
-  "icon": "images/icon.svg",
-  "preferences": [
-    {
-      "id": "code_kw",
-      "type": "keyword",
-      "name": "Trigger keyword",
-      "default_value": "code"
-    }
-  ]
+	"required_api_version": "^2.0.0",
+	"name": "VS Code Recent",
+	"description": "Quickly open recently-opened VS Code project directories and files",
+	"developer_name": "plibither8",
+	"icon": "images/icon.svg",
+	"preferences": [
+		{
+			"id": "code_kw",
+			"type": "keyword",
+			"name": "Trigger keyword",
+			"default_value": "code"
+		},
+		{
+			"id": "excluded_env_vars",
+			"type": "input",
+			"name": "Comma seperated list of env vars to remove when starting vscode, e.g. PYTHONPATH"
+		}
+	]
 }


### PR DESCRIPTION
Added settings input field that can take a comma seperated list of ENV variables to strip before starting vscode.
Added because of PYTHONPATH being set to global python, and interfering with used venv in vscode.

In order to set ENV vars when starting vscode, i've changed `os.system()` to `subprocess.run()`