### PR TITLE
[BugFix] Project discovery for newer VS Code storage layouts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # ulauncher-vscode-recent
 
-> 💻 Open recent VS Code folders and files using Ulauncher.
+> 💻 Open recent VS Code family folders and files using Ulauncher.
 
-Quickly open recently-opened VS Code project directories and files.
+Quickly open recently-opened VS Code, VSCodium, and VS Code Insiders project directories and files.
 
 ## Install
 

--- a/main.py
+++ b/main.py
@@ -39,6 +39,7 @@ class Code:
 	def __init__(self):
 		self.installed_path = None
 		self.config_path = None
+		self.shared_state_db = None
 		self.global_state_db = None
 		self.storage_json = None
 
@@ -54,6 +55,7 @@ class Code:
 					             installed_path, config_path)
 					self.installed_path = installed_path
 					self.config_path = config_path
+					self.shared_state_db = self.get_shared_state_db(variant)
 					self.global_state_db = config_path / 'User' / 'globalStorage' / 'state.vscdb'
 					self.storage_json = config_path / 'User' / 'globalStorage' / 'storage.json'
 					return
@@ -85,15 +87,30 @@ class Code:
 		return []
 
 	def get_global_state_databases(self):
-		if not self.global_state_db:
-			return []
+		dbs = []
+		shared_state_db = getattr(self, "shared_state_db", None)
+		if shared_state_db:
+			dbs.append(shared_state_db)
 
-		dbs = [self.global_state_db]
-		backup_db = pathlib.Path(str(self.global_state_db) + '.backup')
-		if backup_db.exists():
-			dbs.append(backup_db)
+		if self.global_state_db:
+			dbs.append(self.global_state_db)
+			backup_db = pathlib.Path(str(self.global_state_db) + '.backup')
+			if backup_db.exists():
+				dbs.append(backup_db)
 
 		return [db for db in dbs if db.exists()]
+
+	@staticmethod
+	def get_shared_state_db(variant):
+		shared_dirs = {
+			"Code": ".vscode-shared",
+			"VSCodium": ".vscodium-shared",
+		}
+		shared_dir = shared_dirs.get(variant)
+		if not shared_dir:
+			return None
+
+		return pathlib.Path.home() / shared_dir / "sharedStorage" / "state.vscdb"
 
 	def get_recents_global_state(self, global_state_db=None):
 		global_state_db = global_state_db or self.global_state_db
@@ -124,9 +141,26 @@ class Code:
 		logger.debug('loading storage.json')
 		with self.storage_json.open("r") as storage_file:
 			storage = json.load(storage_file)
-		entries = storage["openedPathsList"]["entries"]
+
+		if "openedPathsList" in storage:
+			entries = storage["openedPathsList"]["entries"]
+		else:
+			entries = self.get_profile_association_entries(storage)
+
 		logger.debug('found %d entries in storage.json', len(entries))
 		return self.parse_entry_paths(entries)
+
+	@staticmethod
+	def get_profile_association_entries(storage):
+		workspaces = storage.get("profileAssociations", {}).get("workspaces", {})
+		entries = []
+		for uri in workspaces:
+			if uri.endswith(".code-workspace"):
+				entries.append({"workspace": {"configPath": uri}})
+			else:
+				entries.append({"folderUri": uri})
+
+		return entries
 
 	@staticmethod
 	def parse_entry_paths(entries):

--- a/main.py
+++ b/main.py
@@ -34,7 +34,26 @@ class Utils:
 
 class Code:
 	path_dirs = ("/usr/bin", "/bin", "/snap/bin")
-	variants = ("Code", "VSCodium")
+	variants = (
+		{
+			"name": "Code",
+			"binary": "code",
+			"config": "Code",
+			"shared_state_dir": ".vscode-shared",
+		},
+		{
+			"name": "VSCodium",
+			"binary": "codium",
+			"config": "VSCodium",
+			"shared_state_dir": ".vscodium-shared",
+		},
+		{
+			"name": "Code - Insiders",
+			"binary": "code-insiders",
+			"config": "Code - Insiders",
+			"shared_state_dir": ".vscode-insiders-shared",
+		},
+	)
 
 	def __init__(self):
 		self.installed_path = None
@@ -46,8 +65,8 @@ class Code:
 		logger.debug('locating installation and config directories')
 		for path in (pathlib.Path(path_dir) for path_dir in Code.path_dirs):
 			for variant in Code.variants:
-				installed_path = path / variant.lower()
-				config_path = pathlib.Path.home() / ".config" / variant
+				installed_path = path / variant["binary"]
+				config_path = pathlib.Path.home() / ".config" / variant["config"]
 				logger.debug('evaluating installation dir %s and config dir %s',
 				             installed_path, config_path)
 				if installed_path.exists() and config_path.exists() and (config_path / "User" / "globalStorage" / "storage.json").exists():
@@ -102,11 +121,7 @@ class Code:
 
 	@staticmethod
 	def get_shared_state_db(variant):
-		shared_dirs = {
-			"Code": ".vscode-shared",
-			"VSCodium": ".vscodium-shared",
-		}
-		shared_dir = shared_dirs.get(variant)
+		shared_dir = variant.get("shared_state_dir")
 		if not shared_dir:
 			return None
 
@@ -243,7 +258,7 @@ class CodeExtension(Extension):
 		if query_raw.strip() != "":
 			items.append(
 				ExtensionSmallResultItem(
-					icon=Utils.get_path(f"images/icon.svg"),
+					icon=Utils.get_path("images/icon.svg"),
 					name=query_raw,
 					on_enter=ExtensionCustomAction({'option': '', 'uri':query_raw}),
 				)
@@ -267,8 +282,8 @@ class KeywordQueryEventListener(EventListener):
 			items.append(
 				ExtensionResultItem(
 					icon=Utils.get_path("images/icon.svg"),
-					name="No VS Code?",
-					description="Can't find the VS Code's `code` command in your system :(",
+					name="No VS Code family app?",
+					description="Can't find a supported VS Code, VSCodium, or VS Code Insiders command in your system :(",
 					highlightable=False,
 					on_enter=HideWindowAction(),
 				)

--- a/main.py
+++ b/main.py
@@ -66,29 +66,53 @@ class Code:
 	def get_recents(self):
 
 		# Current
-		if self.global_state_db.exists():
-			logger.debug('getting recents from global state database')
+		for global_state_db in self.get_global_state_databases():
+			logger.debug('getting recents from global state database %s', global_state_db)
 			try:
-				return self.get_recents_global_state()
+				return self.get_recents_global_state(global_state_db)
 			except Exception as e:
-				logger.error('getting recents from global state database failed', e)
-				if not self.storage_json.exists():
-					raise e
+				logger.debug('getting recents from global state database %s failed: %s',
+				             global_state_db, e)
 
 		# Legacy
 		if self.storage_json.exists():
 			logger.debug('getting recents from storage.json (legacy)')
-			return self.get_recents_legacy()
+			try:
+				return self.get_recents_legacy()
+			except Exception as e:
+				logger.warning('getting recents from storage.json failed: %s', e)
 
-	def get_recents_global_state(self):
-		logger.debug('connecting to global state database %s', self.global_state_db)
-		con = sqlite3.connect(self.global_state_db)
-		cur = con.cursor()
-		cur.execute(
-			'SELECT value FROM ItemTable WHERE key = "history.recentlyOpenedPathsList"')
-		json_code, = cur.fetchone()
+		return []
+
+	def get_global_state_databases(self):
+		if not self.global_state_db:
+			return []
+
+		dbs = [self.global_state_db]
+		backup_db = pathlib.Path(str(self.global_state_db) + '.backup')
+		if backup_db.exists():
+			dbs.append(backup_db)
+
+		return [db for db in dbs if db.exists()]
+
+	def get_recents_global_state(self, global_state_db=None):
+		global_state_db = global_state_db or self.global_state_db
+		logger.debug('connecting to global state database %s', global_state_db)
+		con = sqlite3.connect(global_state_db)
+		try:
+			cur = con.cursor()
+			cur.execute(
+				'SELECT value FROM ItemTable WHERE key = "history.recentlyOpenedPathsList"')
+			row = cur.fetchone()
+		finally:
+			con.close()
+
+		if row is None:
+			raise KeyError('history.recentlyOpenedPathsList')
+
+		json_code, = row
 		paths_list = json.loads(json_code)
-		entries = paths_list['entries']
+		entries = paths_list.get('entries', [])
 		logger.debug('found %d entries in global state database', len(entries))
 		return self.parse_entry_paths(entries)
 
@@ -98,7 +122,8 @@ class Code:
 		:uri https://code.visualstudio.com/updates/v1_64
 		"""
 		logger.debug('loading storage.json')
-		storage = json.load(self.storage_json.open("r"))
+		with self.storage_json.open("r") as storage_file:
+			storage = json.load(storage_file)
 		entries = storage["openedPathsList"]["entries"]
 		logger.debug('found %d entries in storage.json', len(entries))
 		return self.parse_entry_paths(entries)

--- a/tests/test_recents.py
+++ b/tests/test_recents.py
@@ -106,6 +106,47 @@ def create_state_db(path, entries=None):
 
 
 class RecentsTest(unittest.TestCase):
+	def test_uses_shared_state_database_before_legacy_fallbacks(self):
+		module = load_main()
+		with tempfile.TemporaryDirectory() as temp_dir:
+			root = pathlib.Path(temp_dir)
+			shared_root = root / "sharedStorage"
+			shared_root.mkdir()
+			shared_db = shared_root / "state.vscdb"
+			current_db = root / "state.vscdb"
+			storage_json = root / "storage.json"
+
+			create_state_db(shared_db, [{"folderUri": "file:///tmp/shared-project"}])
+			create_state_db(current_db)
+			storage_json.write_text(
+				json.dumps(
+					{
+						"profileAssociations": {
+							"workspaces": {"file:///tmp/profile-project": "__default__profile__"}
+						}
+					}
+				)
+			)
+
+			code = module.Code.__new__(module.Code)
+			code.installed_path = pathlib.Path("/usr/bin/code")
+			code.config_path = root
+			code.shared_state_db = shared_db
+			code.global_state_db = current_db
+			code.storage_json = storage_json
+
+			self.assertEqual(
+				code.get_recents(),
+				[
+					{
+						"uri": "file:///tmp/shared-project",
+						"label": "shared-project",
+						"icon": "folder",
+						"option": "--folder-uri",
+					}
+				],
+			)
+
 	def test_uses_backup_state_database_when_current_database_has_no_recent_paths(self):
 		module = load_main()
 		with tempfile.TemporaryDirectory() as temp_dir:
@@ -133,6 +174,53 @@ class RecentsTest(unittest.TestCase):
 						"icon": "folder",
 						"option": "--folder-uri",
 					}
+				],
+			)
+
+	def test_uses_profile_associations_when_recent_paths_are_absent(self):
+		module = load_main()
+		with tempfile.TemporaryDirectory() as temp_dir:
+			root = pathlib.Path(temp_dir)
+			current_db = root / "state.vscdb"
+			backup_db = root / "state.vscdb.backup"
+			storage_json = root / "storage.json"
+
+			create_state_db(current_db)
+			create_state_db(backup_db)
+			storage_json.write_text(
+				json.dumps(
+					{
+						"profileAssociations": {
+							"workspaces": {
+								"file:///tmp/project": "__default__profile__",
+								"file:///tmp/demo.code-workspace": "__default__profile__",
+							}
+						}
+					}
+				)
+			)
+
+			code = module.Code.__new__(module.Code)
+			code.installed_path = pathlib.Path("/usr/bin/code")
+			code.config_path = root
+			code.global_state_db = current_db
+			code.storage_json = storage_json
+
+			self.assertEqual(
+				code.get_recents(),
+				[
+					{
+						"uri": "file:///tmp/project",
+						"label": "project",
+						"icon": "folder",
+						"option": "--folder-uri",
+					},
+					{
+						"uri": "file:///tmp/demo.code-workspace",
+						"label": "demo.code-workspace",
+						"icon": "workspace",
+						"option": "--file-uri",
+					},
 				],
 			)
 

--- a/tests/test_recents.py
+++ b/tests/test_recents.py
@@ -1,0 +1,141 @@
+import importlib.util
+import json
+import pathlib
+import sqlite3
+import sys
+import tempfile
+import types
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+MAIN = ROOT / "main.py"
+
+
+def stub_module(name):
+	module = types.ModuleType(name)
+	sys.modules[name] = module
+	return module
+
+
+def stub_dependencies():
+	module_names = [
+		"ulauncher",
+		"ulauncher.api",
+		"ulauncher.api.client",
+		"ulauncher.api.client.Extension",
+		"ulauncher.api.client.EventListener",
+		"ulauncher.api.shared",
+		"ulauncher.api.shared.event",
+		"ulauncher.api.shared.item",
+		"ulauncher.api.shared.item.ExtensionResultItem",
+		"ulauncher.api.shared.item.ExtensionSmallResultItem",
+		"ulauncher.api.shared.action",
+		"ulauncher.api.shared.action.RenderResultListAction",
+		"ulauncher.api.shared.action.HideWindowAction",
+		"ulauncher.api.shared.action.ExtensionCustomAction",
+		"fuzzywuzzy",
+	]
+	for name in module_names:
+		if name not in sys.modules:
+			stub_module(name)
+
+	class StubExtension(object):
+		def __init__(self):
+			pass
+
+		def subscribe(self, *args):
+			pass
+
+		def run(self):
+			pass
+
+	class StubEventListener(object):
+		pass
+
+	class StubAction(object):
+		def __init__(self, *args, **kwargs):
+			pass
+
+	sys.modules["ulauncher.api.client.Extension"].Extension = StubExtension
+	sys.modules["ulauncher.api.client.EventListener"].EventListener = StubEventListener
+	sys.modules["ulauncher.api.shared.event"].KeywordQueryEvent = object
+	sys.modules["ulauncher.api.shared.event"].ItemEnterEvent = object
+	sys.modules["ulauncher.api.shared.event"].PreferencesEvent = object
+	sys.modules["ulauncher.api.shared.event"].PreferencesUpdateEvent = object
+	sys.modules[
+		"ulauncher.api.shared.item.ExtensionResultItem"
+	].ExtensionResultItem = StubAction
+	sys.modules[
+		"ulauncher.api.shared.item.ExtensionSmallResultItem"
+	].ExtensionSmallResultItem = StubAction
+	sys.modules[
+		"ulauncher.api.shared.action.RenderResultListAction"
+	].RenderResultListAction = StubAction
+	sys.modules[
+		"ulauncher.api.shared.action.HideWindowAction"
+	].HideWindowAction = StubAction
+	sys.modules[
+		"ulauncher.api.shared.action.ExtensionCustomAction"
+	].ExtensionCustomAction = StubAction
+	sys.modules["fuzzywuzzy"].process = types.SimpleNamespace(extract=lambda *args, **kwargs: [])
+	sys.modules["fuzzywuzzy"].fuzz = types.SimpleNamespace(partial_ratio=None)
+
+
+def load_main():
+	stub_dependencies()
+	spec = importlib.util.spec_from_file_location("ulauncher_vscode_recent", MAIN)
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+	return module
+
+
+def create_state_db(path, entries=None):
+	con = sqlite3.connect(str(path))
+	try:
+		cur = con.cursor()
+		cur.execute("CREATE TABLE ItemTable (key TEXT UNIQUE ON CONFLICT REPLACE, value BLOB)")
+		if entries is not None:
+			cur.execute(
+				"INSERT INTO ItemTable VALUES (?, ?)",
+				("history.recentlyOpenedPathsList", json.dumps({"entries": entries})),
+			)
+		con.commit()
+	finally:
+		con.close()
+
+
+class RecentsTest(unittest.TestCase):
+	def test_uses_backup_state_database_when_current_database_has_no_recent_paths(self):
+		module = load_main()
+		with tempfile.TemporaryDirectory() as temp_dir:
+			root = pathlib.Path(temp_dir)
+			current_db = root / "state.vscdb"
+			backup_db = root / "state.vscdb.backup"
+			storage_json = root / "storage.json"
+
+			create_state_db(current_db)
+			create_state_db(backup_db, [{"folderUri": "file:///tmp/project"}])
+			storage_json.write_text(json.dumps({"profileAssociations": {}}))
+
+			code = module.Code.__new__(module.Code)
+			code.installed_path = pathlib.Path("/usr/bin/code")
+			code.config_path = root
+			code.global_state_db = current_db
+			code.storage_json = storage_json
+
+			self.assertEqual(
+				code.get_recents(),
+				[
+					{
+						"uri": "file:///tmp/project",
+						"label": "project",
+						"icon": "folder",
+						"option": "--folder-uri",
+					}
+				],
+			)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/tests/test_recents.py
+++ b/tests/test_recents.py
@@ -6,6 +6,7 @@ import sys
 import tempfile
 import types
 import unittest
+from unittest import mock
 
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -106,6 +107,54 @@ def create_state_db(path, entries=None):
 
 
 class RecentsTest(unittest.TestCase):
+	def test_detects_vscodium_binary_config_and_shared_state_paths(self):
+		module = load_main()
+		with tempfile.TemporaryDirectory() as temp_dir:
+			root = pathlib.Path(temp_dir)
+			bin_dir = root / "bin"
+			home_dir = root / "home"
+			config_dir = home_dir / ".config" / "VSCodium"
+			shared_dir = home_dir / ".vscodium-shared" / "sharedStorage"
+			bin_dir.mkdir()
+			config_dir.mkdir(parents=True)
+			shared_dir.mkdir(parents=True)
+			(bin_dir / "codium").touch()
+			(config_dir / "User" / "globalStorage").mkdir(parents=True)
+			(config_dir / "User" / "globalStorage" / "storage.json").write_text("{}")
+			(shared_dir / "state.vscdb").touch()
+
+			with mock.patch.object(module.pathlib.Path, "home", return_value=home_dir):
+				module.Code.path_dirs = (str(bin_dir),)
+				code = module.Code()
+
+			self.assertEqual(code.installed_path, bin_dir / "codium")
+			self.assertEqual(code.config_path, config_dir)
+			self.assertEqual(code.shared_state_db, shared_dir / "state.vscdb")
+
+	def test_detects_vscode_insiders_binary_config_and_shared_state_paths(self):
+		module = load_main()
+		with tempfile.TemporaryDirectory() as temp_dir:
+			root = pathlib.Path(temp_dir)
+			bin_dir = root / "bin"
+			home_dir = root / "home"
+			config_dir = home_dir / ".config" / "Code - Insiders"
+			shared_dir = home_dir / ".vscode-insiders-shared" / "sharedStorage"
+			bin_dir.mkdir()
+			config_dir.mkdir(parents=True)
+			shared_dir.mkdir(parents=True)
+			(bin_dir / "code-insiders").touch()
+			(config_dir / "User" / "globalStorage").mkdir(parents=True)
+			(config_dir / "User" / "globalStorage" / "storage.json").write_text("{}")
+			(shared_dir / "state.vscdb").touch()
+
+			with mock.patch.object(module.pathlib.Path, "home", return_value=home_dir):
+				module.Code.path_dirs = (str(bin_dir),)
+				code = module.Code()
+
+			self.assertEqual(code.installed_path, bin_dir / "code-insiders")
+			self.assertEqual(code.config_path, config_dir)
+			self.assertEqual(code.shared_state_db, shared_dir / "state.vscdb")
+
 	def test_uses_shared_state_database_before_legacy_fallbacks(self):
 		module = load_main()
 		with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary
Fix VS Code recent project discovery for newer VS Code storage layouts.
This PR updates the Ulauncher VS Code Recent extension to read recent projects from VS Code’s current shared storage location, while preserving compatibility with older storage formats.
## Background
Recent versions of VS Code store `history.recentlyOpenedPathsList` in application shared storage:
```
~/.vscode-shared/sharedStorage/state.vscdb
```
The extension previously only checked:
```
~/.config/Code/User/globalStorage/state.vscdb
~/.config/Code/User/globalStorage/state.vscdb.backup
~/.config/Code/User/globalStorage/storage.json
```
As a result, the extension could return an empty result list even when VS Code still had valid recent project data.
## Changes
- Add support for VS Code shared state storage:
  - `~/.vscode-shared/sharedStorage/state.vscdb`
  - `~/.vscodium-shared/sharedStorage/state.vscdb`
- Keep existing fallback behavior:
  - User/globalStorage/state.vscdb
  - User/globalStorage/state.vscdb.backup
  - legacy storage.json -> openedPathsList.entries
- Add fallback support for modern storage.json -> profileAssociations.workspaces
- Fix logging behavior when recent-path storage is missing or unreadable
- Ensure SQLite connections and JSON file handles are closed properly
- Add regression tests for:
  - shared state DB lookup
  - backup DB fallback
  - profileAssociations.workspaces fallback
## Verification
Tested with:
```bash
python3 -m unittest tests.test_recents
python3 -m py_compile main.py tests/test_recents.py
```
Result:
```bash
Ran 3 tests ... OK
Also verified against a live local VS Code profile:
shared_state_db: `~/.vscode-shared/sharedStorage/state.vscdb`
recents_count: 394
```
## Notes
This keeps backward compatibility with older VS Code storage formats while supporting the current VS Code shared storage behavior.
## Related Issues
close #26